### PR TITLE
Added DSL and some examples using it.

### DIFF
--- a/examples/src/dueling_banjos_dsl.nim
+++ b/examples/src/dueling_banjos_dsl.nim
@@ -1,0 +1,81 @@
+from common import nil
+import paramidi
+import paramidi/[tsf, utils]
+import paramidi_soundfonts
+
+const
+  measure1 = (1/16, b, +c, 1/8, +d, b, +c, a, b, g, a)
+  measure2 = (1/16, g, g, 1/8, g, a, b, +c, +d, +c, 1/2, b)
+  measure3 = (1/16, {d, -b, -g}, {d, -b, -g},
+              1/8, {d, -b, -g}, {e, c, -g}, {d, -b, -g})
+  measure4 = (1/16, r, r, 1/8, g, r, d, r, g, g, d)
+  measure5 = (1/4, g, 1/8, a, b, 1/4, g, 1/8, a, d)
+  measure6 = (1/4, g, 1/8, a, b, 1/4, g, 1/8, {f, -a}, b, 1/4, c)
+  score = makeMusic:
+    tempo = 80
+    octave = 3
+    guitar: measure1
+    banjo: measure1
+    guitar: measure1
+    guitar:
+      1/2: d
+      1/8: [g, g, a, b, g, b]
+      1/2: a
+    banjo:
+      1/8: [g, g, a, b]
+      1/2: g
+    guitar:
+      octave = 2
+      measure2
+    banjo: measure2
+    guitar: measure2
+    banjo: measure2
+    octave = 4
+    guitar: measure3
+    banjo: measure3
+    guitar: measure3
+    banjo: measure3
+    guitar:
+      octave = 2
+      measure1
+    banjo:
+      octave = 3
+      measure1
+    tempo = 120
+    octave = 3
+    concurrent:
+      banjo: measure1
+      guitar: measure4
+    concurrent:
+      banjo: measure1
+      guitar: measure4
+    concurrent:
+      banjo: measure1
+      guitar: measure5
+    concurrent:
+      banjo: measure1
+      guitar: measure6
+
+when isMainModule:
+  # get the sound font
+  # in a release build, embed it in the binary.
+  when defined(release):
+    const soundfont = staticRead("paramidi_soundfonts/generaluser.sf2")
+    var sf = tsf_load_memory(soundfont.cstring, soundfont.len.cint)
+  # during dev, read it from the disk
+  else:
+    var sf = tsf_load_filename(paramidi_soundfonts.getSoundFontPath("generaluser.sf2"))
+  # render the score
+  const sampleRate = 44100
+  tsf_set_output(sf, TSF_MONO, sampleRate, 0)
+  var res = render[cshort](compile(score), sf, sampleRate)
+  # create the wav file and play it
+  const
+    writeToDisk = true # if false, the wav file will only exist in memory
+    padding = 500f     # add a half second so it doesn't cut off abruptly
+  when writeToDisk:
+    common.writeFile("output.wav", res.data, res.data.len.uint32, sampleRate)
+    common.play("output.wav", int(res.seconds * 1000f + padding))
+  else:
+    let wav = common.writeMemory(res.data, res.data.len.uint32, sampleRate)
+    common.play(wav, int(res.seconds * 1000f + padding))

--- a/examples/src/piano_dsl.nim
+++ b/examples/src/piano_dsl.nim
@@ -1,0 +1,39 @@
+from common import nil
+import paramidi
+import paramidi/[tsf, utils]
+import paramidi_soundfonts
+
+const
+  score = makeMusic:
+    piano:
+      tempo = 74
+      1/8: {-d, -a, e, fx}
+      1/2: {fx, +d}
+      1/8: [{-e, e, +c}, a]
+      1/2: {c, e}
+      1/8: [{-d, -a, e, fx}, a, +d, +cx, +e, +d, b, +cx]
+      1/2: [{-e, c, a}, {c, e}]
+
+when isMainModule:
+  # get the sound font
+  # in a release build, embed it in the binary.
+  when defined(release):
+    const soundfont = staticRead("paramidi_soundfonts/generaluser.sf2")
+    var sf = tsf_load_memory(soundfont.cstring, soundfont.len.cint)
+  # during dev, read it from the disk
+  else:
+    var sf = tsf_load_filename(paramidi_soundfonts.getSoundFontPath("generaluser.sf2"))
+  # render the score
+  const sampleRate = 44100
+  tsf_set_output(sf, TSF_MONO, sampleRate, 0)
+  var res = render[cshort](compile(score), sf, sampleRate)
+  # create the wav file and play it
+  const
+    writeToDisk = true # if false, the wav file will only exist in memory
+    padding = 500f     # add a half second so it doesn't cut off abruptly
+  when writeToDisk:
+    common.writeFile("output.wav", res.data, res.data.len.uint32, sampleRate)
+    common.play("output.wav", int(res.seconds * 1000f + padding))
+  else:
+    let wav = common.writeMemory(res.data, res.data.len.uint32, sampleRate)
+    common.play(wav, int(res.seconds * 1000f + padding))

--- a/src/paramidi/utils.nim
+++ b/src/paramidi/utils.nim
@@ -1,0 +1,78 @@
+import std/macros
+import paramidi
+
+proc instrumentImpl(body: NimNode): seq[NimNode]
+proc concurentImpl(body: NimNode): NimNode
+
+proc instrumentImpl(body: NimNode): seq[NimNode] =
+  for call in body:
+    case call.kind:
+    of nnkInfix:
+      let invoke = call.copyNimTree
+      invoke.del(invoke.len - 1, 1)
+      result.add invoke
+      if call[^1][0].kind in {nnkBracket}:
+        for x in call[^1][0]:
+          result.add x
+      else:
+        result.add call[^1][0]
+    of nnkAsgn:
+      result.add nnkPar.newTree(nnkExprColonExpr.newTree(call[0], call[1]))
+    of nnkCall:
+      if call[0].eqIdent"concurrent":
+        result.add call.concurentImpl
+        echo result[^1].repr
+      else:
+        result.add nnkTupleConstr.newTree(call[0])
+        result[^1].add call[^1].instrumentImpl
+    of nnkIdent:
+      result.add nnkTupleConstr.newTree(call)
+    else: discard
+
+proc concurentImpl(body: NimNode): NimNode =
+  result = nnkTupleConstr.newTree(nnkTupleConstr.newTree(nnkExprColonExpr.newTree(ident"mode",
+      ident"concurrent")))
+  result.add body[^1].instrumentImpl
+
+
+macro makeMusic*(body: untyped): untyped =
+  ## DSL for making easy midi music.
+  ## `a` = `b` is used for things like `octave` or `tempo`.
+  ## `1/8:` is used for a single __Word that is correct here__
+  ## `[]` surrounds sequential entires in a note.
+  ## `concurrent` can be used for blocks of concurrent music.
+  runnableExamples:
+    const test = makeMusic:
+      piano:
+        tempo = 74
+        1/8: {-d, -a, e, fx}
+        1/2: {fx, +d}
+        1/8: [{-e, e, +c}, a]
+        1/2: {c, e}
+        1/8: [{-d, -a, e, fx}, a, +d, +cx, +e, +d, b, +cx]
+        1/2: [{-e, c, a}, {c, e}]
+  result = nnkTupleConstr.newNimNode
+  result.add instrumentImpl(body)
+
+macro concurrentMusic*(body: untyped): untyped =
+  ## DSL for making easy concurrent midi music.
+  ## The base block is concurrent, same rules as `makeMusic` apply.
+  ## `a` = `b` is used for things like `octave` or `tempo`.
+  ## `1/8:` is used for a single __Word that is correct here__
+  ## `[]` surrounds sequential entires in a note.
+  ## `concurrent` can be used for blocks of concurrent music.
+  runnableExamples:
+    const test2 = concurrentMusic:
+      piano:
+        tempo = 20
+        1/8: {-d, -a, e, fx}
+        1/2: {fx, +d}
+        1/8: [{-e, e, +c}, a]
+      agogo:
+        tempo = 14
+        1/8: {-d, -a, e, fx}
+        1/2: {fx, +d}
+        1/8: [{-e, e, +c}, a]
+
+  result = nnkTupleConstr.newTree(nnkPar.newTree(nnkExprColonExpr.newTree(ident"mode", newLit(concurrent))))
+  result.add body.instrumentImpl


### PR DESCRIPTION
No clue your view on this, but after watching your talk I got inspiration to throw on some macro magic to make it a little more ergonomic to write.

Music is still written sequentially, but a few rules for this:
-`[]` is for a  sequence of notes
-`a = b` is for `(octave: 3)` and similar


Some examples:
```nim
import paramidi/utils
const score = makeMusic:
  piano:
    tempo = 74
    1/8: {-d, -a, e, fx}
    1/2: {fx, +d}
    1/8: [{-e, e, +c}, a]
    1/2: {c, e}
    1/8: [{-d, -a, e, fx}, a, +d, +cx, +e, +d, b, +cx]
    1/2: [{-e, c, a}, {c, e}]
 ```
 ```nim
import paramidi/utils
const score = concurrentMusic:
  piano:
    tempo = 20
    1/8: {-d, -a, e, fx}
    1/2: {fx, +d}
    1/8: [{-e, e, +c}, a]
  agogo:
    tempo = 14
    1/8: {-d, -a, e, fx}
    1/2: {fx, +d}
    1/8: [{-e, e, +c}, a]
```
 
